### PR TITLE
add dkms.conf and remove _mod suffix from module names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
 KVERSION ?= $(shell uname -r)
 KDIR ?= /lib/modules/$(KVERSION)/build
-obj-m	:= vinput_mod.o vkbd_mod.o vts_mt_mod.o vmouse_mod.o
-
-vinput_mod-y := vinput.o
-vkbd_mod-y := vkbd.o
-vts_mt_mod-y := vts_mt.o
-vmouse_mod-y := vmouse.o
+obj-m	:= vinput.o vkbd.o vts_mt.o vmouse.o
 
 all:
 	$(MAKE) -C $(KDIR) M=$(PWD) modules

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,15 @@
+PACKAGE_NAME="vinput"
+PACKAGE_VERSION="#MODULE_VERSION#"
+AUTOINSTALL="yes"
+
+MAKE[0]="make KVERSION=$kernelver"
+CLEAN="make clean"
+
+BUILT_MODULE_NAME[0]="vinput"
+BUILT_MODULE_NAME[1]="vkbd"
+BUILT_MODULE_NAME[2]="vmouse"
+BUILT_MODULE_NAME[3]="vts_mt"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/vinput"
+DEST_MODULE_LOCATION[1]="/kernel/drivers/vinput"
+DEST_MODULE_LOCATION[2]="/kernel/drivers/vinput"
+DEST_MODULE_LOCATION[3]="/kernel/drivers/vinput"


### PR DESCRIPTION
Hi :-)

Wonderful piece of software you have here :heart: 

I've renamed the module files to make them load with `modprobe vkbd` instead of `modprobe vkbd_mod`.

Si tu le veux ;-)