### PR TITLE
Kernel 6.4

### DIFF
--- a/vinput.c
+++ b/vinput.c
@@ -24,7 +24,7 @@ static dev_t vinput_dev;
 static struct spinlock vinput_lock;
 static struct class vinput_class;
 
-struct vinput_device *vinput_get_device_by_type(const char *type)
+static struct vinput_device *vinput_get_device_by_type(const char *type)
 {
 	int found = 0;
 	struct vinput_device *vinput;
@@ -45,7 +45,7 @@ struct vinput_device *vinput_get_device_by_type(const char *type)
 	return ERR_PTR(-ENODEV);
 }
 
-struct vinput *vinput_get_vdevice_by_id(long id)
+static struct vinput *vinput_get_vdevice_by_id(long id)
 {
 	struct vinput *vinput = NULL;
 	struct list_head *curr;

--- a/vinput.c
+++ b/vinput.c
@@ -320,7 +320,9 @@ ATTRIBUTE_GROUPS(vinput_class);
 
 static struct class vinput_class = {
 	.name = "vinput",
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 	.owner = THIS_MODULE,
+#endif
 	.class_groups = vinput_class_groups,
 };
 

--- a/vinput.c
+++ b/vinput.c
@@ -7,6 +7,7 @@
 #include <linux/slab.h>
 #include <linux/types.h>
 #include <linux/cdev.h>
+#include <linux/version.h>
 #include <asm/uaccess.h>
 
 #include "vinput.h"
@@ -233,7 +234,13 @@ static int vinput_register_vdevice(struct vinput *vinput)
 	return err;
 }
 
-static ssize_t export_store(struct class *class, struct class_attribute *attr,
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 4, 0)
+#define OPT_CONST_6_4 const
+#else
+#define OPT_CONST_6_4
+#endif
+
+static ssize_t export_store(OPT_CONST_6_4 struct class *class, OPT_CONST_6_4 struct class_attribute *attr,
 			    const char *buf, size_t len)
 {
 	int err;
@@ -272,7 +279,7 @@ fail:
 	return err;
 }
 
-static ssize_t unexport_store(struct class *class, struct class_attribute *attr,
+static ssize_t unexport_store(OPT_CONST_6_4 struct class *class, OPT_CONST_6_4 struct class_attribute *attr,
 			      const char *buf, size_t len)
 {
 	int err;


### PR DESCRIPTION
every now and then, vinput makes an appearance in my life. happy to help with keeping it alive.

gcc added some warnings and the drivers API of the kernel changed back in 2023.